### PR TITLE
fix dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4530,8 +4530,7 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5971,7 +5970,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "prepublishOnly": "npm run compile"
   },
   "dependencies": {
-    "roman-numerals": "^0.3.2"
+    "roman-numerals": "^0.3.2",
+    "strip-indent": "^3.0.0"
   },
   "devDependencies": {
     "@friends-library/dev": "^4.1.18",
     "@types/glob": "^7.1.3",
     "@types/roman-numerals": "^0.3.0",
     "@types/strip-indent": "^3.0.2",
-    "glob": "^7.1.6",
-    "strip-indent": "^3.0.0"
+    "glob": "^7.1.6"
   }
 }


### PR DESCRIPTION
the src/__tests__/helpers.ts file is included in the npm package, so the `strip-indent` npm package needs to not be a DEV dep, was causing netlify build error for the API package, which now consumes the parser